### PR TITLE
Enable raw sockets for smokeping

### DIFF
--- a/charts/stable/smokeping/values.yaml
+++ b/charts/stable/smokeping/values.yaml
@@ -24,6 +24,9 @@ portal:
     enabled: true
 securityContext:
   container:
+    capabilities:
+      add:
+        - NET_RAW
     readOnlyRootFilesystem: false
     runAsNonRoot: false
     allowPrivilegeEscalation: true


### PR DESCRIPTION
enable raw sockets to allow fping to fire probes.  Otherwise, you run into https://github.com/linuxserver/docker-smokeping/issues/99